### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Make sure that all plugin media files are exposed by django-fluent-contents_::
 
 This tag should be placed at the bottom of the page, after all plugins are rendered.
 For more configuration options - e.g. integration with django-compressor -
-see the `template tag documentation <http://django-fluent-contents.readthedocs.org/en/latest/templatetags.html#frontend-media>`_.
+see the `template tag documentation <https://django-fluent-contents.readthedocs.io/en/latest/templatetags.html#frontend-media>`_.
 
 CSS Code
 ~~~~~~~~


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
